### PR TITLE
Feature/pyconfigure

### DIFF
--- a/python/pkgsrcrecords.cc
+++ b/python/pkgsrcrecords.cc
@@ -8,6 +8,9 @@
    ##################################################################### */
 									/*}}}*/
 // Include Files							/*{{{*/
+
+#include "config.h"
+
 #include "generic.h"
 #include "apt_pkgmodule.h"
 
@@ -75,6 +78,7 @@ static PyObject *PkgSrcRecordsRestart(PyObject *Self,PyObject *Args)
    return HandleErrors(Py_None);
 }
 
+#if HAVE_PKGSRCRECORDS_STEP
 static char *doc_PkgSrcRecordsStep =
     "step() -> bool\n\n"
     "Go to the source package. Each call moves\n"
@@ -97,12 +101,15 @@ static PyObject *PkgSrcRecordsStep(PyObject *Self,PyObject *Args)
 
    return PyBool_FromLong(1);
 }
+#endif
 
 static PyMethodDef PkgSrcRecordsMethods[] =
 {
    {"lookup",PkgSrcRecordsLookup,METH_VARARGS,doc_PkgSrcRecordsLookup},
    {"restart",PkgSrcRecordsRestart,METH_VARARGS,doc_PkgSrcRecordsRestart},
+#if HAVE_PKGSRCRECORDS_STEP
    {"step",PkgSrcRecordsStep,METH_VARARGS,doc_PkgSrcRecordsStep},
+#endif
    {}
 };
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,22 @@ import sys
 from distutils.core import setup, Extension
 cmdclass = {}
 
+CONFIG_H_TESTS = (
+    ("const Parser* Step();", "/usr/include/apt-pkg/srcrecords.h", "HAVE_PKGSRCRECORDS_STEP"),
+)
+
+def generate_config_h():
+    config_h = os.path.join(os.path.dirname(__file__), "python", "config.h")
+    with open(config_h, "w") as f:
+        f.write("/* THIS FILE IS AUTO GENERATED - DO NOT EDIT */\n")
+        for needle, include, define in CONFIG_H_TESTS:
+            f.write("#define %s " % define)
+            if needle in open(include).read():
+                f.write("1\n")
+            else:
+                f.write("0\n")
+
+
 try:
     from DistUtilsExtra.command import build_extra, build_i18n
     from DistUtilsExtra.auto import clean_build_tree
@@ -41,6 +57,7 @@ apt_inst = Extension("apt_inst", files, libraries=["apt-pkg", "apt-inst"])
 
 # Replace the leading _ that is used in the templates for translation
 if len(sys.argv) > 1 and sys.argv[1] == "build":
+    generate_config_h()
     if not os.path.exists("build/data/templates/"):
         os.makedirs("build/data/templates")
     for template in glob.glob('data/templates/*.info.in'):


### PR DESCRIPTION
This branch adds a config.h automake/autoconf style header so that we can detect what features libapt has for us. Quite simple currently but good for people who use e.g. pip to build pyhton-apt in their virtualenv but who have a older version of libapt installed. Only 931b048 is relevant here.
