### PR TITLE
Add test for adding architectures on the fly

### DIFF
--- a/apt/cache.py
+++ b/apt/cache.py
@@ -94,10 +94,12 @@ class Cache(object):
             apt_pkg.config.set("Dir", rootdir)
             apt_pkg.config.set("Dir::State::status",
                                rootdir + "/var/lib/dpkg/status")
-            # also set dpkg to the rootdir path so that its called for the
-            # --print-foreign-architectures call
-            apt_pkg.config.set("Dir::bin::dpkg",
-                               os.path.join(rootdir, "usr", "bin", "dpkg"))
+            # if the user hasn't modified it already, set dpkg to the
+            # rootdir path so that its called for the
+            # --print-foreign-architectures call 
+            if apt_pkg.config.find_file("Dir::bin::dpkg") == "/usr/bin/dpkg":
+                apt_pkg.config.set("Dir::bin::dpkg",
+                                   os.path.join(rootdir, "usr", "bin", "dpkg"))
             # create required dirs/files when run with special rootdir
             # automatically
             self._check_and_create_required_dirs(rootdir)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -35,6 +35,12 @@ class AptTestCase(unittest.TestCase):
         self._make_dirs()
         self._make_files()
         self._make_helpers()
+        # common settings needed for the tests
+        apt.apt_pkg.config.set("Dir::Cache::pkgcache", "")
+        apt.apt_pkg.config.set("Dir::Cache::srcpkgcache", "")
+        apt.apt_pkg.config.clear("APT::Update::Post-Invoke")
+        apt.apt_pkg.config.clear("APT::Update::Post-Invoke-Success")
+        apt.apt_pkg.config.clear("DPkg::Post-Invoke")
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python
+#
+# Copyright (C) 2014 Canonical
+#
+# Author: Michael Vogt <mvo@ubuntu.com>
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.
+
+import os
+import shutil
+import sys
+import tempfile
+from textwrap import dedent
+import unittest
+
+from test_all import get_library_dir
+libdir = get_library_dir()
+if libdir:
+    sys.path.insert(0, libdir)
+
+import apt
+
+
+def touch(filename):
+    with open(filename, "a"):
+        pass
+
+
+class AptTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self._make_dirs()
+        self._make_files()
+        self._make_helpers()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def _make_dirs(self):
+        for dirname in ["/bin", "/etc/apt", "/aptarchive/", "/var/lib/dpkg"]:
+            os.makedirs(self.temp_dir + dirname)
+
+    def _make_files(self):
+        touch(self.temp_dir + "/aptarchive/Packages")
+        touch(self.temp_dir + "/aptarchive/Sources")
+        with open(self.temp_dir + "/etc/apt/sources.list", "w") as f:
+            f.write(
+                "deb file:{tmpdir}/aptarchive /".format(tmpdir=self.temp_dir))
+
+    def _make_helpers(self):
+        self.dpkg = os.path.join(self.temp_dir, "bin", "fake_dpkg")
+        with open(self.dpkg, "w") as f:
+            f.write(dedent("""\
+            #!/bin/sh
+            dpkg --root={TMPWORKINGDIRECTORY}/ --force-not-root --force-bad-path --log={TMPWORKINGDIRECTORY}/var/log/dpkg.log "$@"
+            """.format(TMPWORKINGDIRECTORY=self.temp_dir)))
+        os.chmod(self.dpkg, 0o755)
+        apt.apt_pkg.config.set("dir::bin::dpkg", self.dpkg)
+
+    PKG_COUNTER = 0
+    def make_package(self, name="", version="1.0", arch="all"):
+        if name == "":
+            name = "pkg-{}".format(self.PKG_COUNTER)
+            self.PKG_COUNTER += 1
+        packages = os.path.join(self.temp_dir, "aptarchive", "Packages")
+        with open(packages, "a") as f:
+            f.write(dedent("""\
+            Package: {name}
+            Installed-Size: 136
+            Maintainer: Joe Blow <joe@blow.com>
+            Architecture: {arch}
+            Version: {version}
+            Filename: pool/{name}_{version}_{arch}.deb
+            Size: 12345
+            MD5sum: 3a8c96814b0201c285274fded3e2d203
+            SHA1: 05a3c9d5ced88fc51f3aa3166b0ca4030dcc4e49
+            Description: Test packge
+             with some description
+
+            """.format(name=name,
+                       version=version,
+                       arch=arch)))
+        return name
+
+
+ 

--- a/tests/test_multiarch.py
+++ b/tests/test_multiarch.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+#
+# Copyright (C) 2014 Canonical
+#
+# Author: Michael Vogt <mvo@ubuntu.com>
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.
+
+import subprocess
+import sys
+import unittest
+
+
+from test_all import get_library_dir
+libdir = get_library_dir()
+if libdir:
+    sys.path.insert(0, libdir)
+
+import apt
+from helpers import (
+    AptTestCase,
+)
+
+
+class MultiarchTestCase(AptTestCase):
+    """Test that adding a architecture on the fly works"""
+
+    def test_normal(self):
+        pkgname_native = self.make_package()
+        cache = apt.Cache(rootdir=self.temp_dir)
+        cache.update()
+        cache.open()
+        self.assertEqual(len(cache), 1)
+        self.assertEqual(cache[pkgname_native].name, pkgname_native)
+
+    def test_multiarch_add(self):
+        foreign_arch = "foo"
+        pkgname_native = self.make_package()
+        pkgname_foreign = self.make_package(arch=foreign_arch)
+        subprocess.check_call(
+            [self.dpkg, "--add-architecture", foreign_arch])
+        # get the cache
+        cache = apt.Cache(rootdir=self.temp_dir)
+        cache.update()
+        cache.open()
+        self.assertEqual(cache._have_multi_arch, True)
+        self.assertEqual(
+            set([pkg.name for pkg in cache]),
+            set([pkgname_native, "%s:%s" % (pkgname_foreign, foreign_arch)]))
+        
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This test ensures that "dpkg --add-architecture foo" works and
that opening a cache is now a multiarch cache with the added
architecure.

It also improves the tests and adds a new tests/helpers.py that
creates a fake dpkg that can install packages. Plus a new
make_package() method to create test packages on the fly.
